### PR TITLE
🤖 Add CSS styles to make the h1.title element bolder and darker

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,6 +11,13 @@ a {
   text-decoration: none;
   color: black;
 }
+
 * {
   box-sizing: border-box;
+}
+
+.directory-menu .content h1.title {
+  font-weight: 900;
+  color: #1a1a1a;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
## 🤖 AI-Generated Fix

The task requires making the 'JACKETS' h1 title element bolder and darker. Based on the CSS selector provided (div > div > div.homepage:nth-of-type(2) > div.directory-menu > div.undefined:nth-of-type(2) > div.content:nth-of-type(2) > h1.title), I need to add CSS rules that target this specific element. I'll add styles to increase the font-weight to make it bolder and change the color to a darker shade (dark gray/black). Since the project uses SASS according to package.json, I'll add these styles to the App.css file.

---

### Changes Made

#### `src/App.css`
Added CSS rules to make h1.title elements bolder and darker

---

### ⚠️ Important

This PR was generated by AI based on a comment/task. Please:

1. **Review all changes carefully** before merging
2. **Test the changes** to ensure they work as expected
3. **Check for any unintended side effects**

---

**Source Comment:** a72ec5b2-a362-44b6-b6b4-7c2ae362a5da

*Generated by Halo Frame AI*