### PR TITLE
🤖 Change MENS title color from blue to black in directory menu

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -37,6 +37,6 @@ a {
 
 .directory-menu div.large:nth-of-type(5) .content h1.title {
   font-weight: 900;
-  color: blue;
+  color: black;
   text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
## 🤖 AI-Generated Fix

The feedback requests to make the color black for the MENS title element. Based on the CSS selector path 'div > div > div.homepage:nth-of-type(2) > div.directory-menu > div.large:nth-of-type(5) > div.content:nth-of-type(2) > h1.title', this targets the h1 element in the 5th large directory menu item. Looking at the App.css file, there's a specific rule '.directory-menu div.large:nth-of-type(5) .content h1.title' that currently sets the color to blue. This needs to be changed to black to address the feedback.

---

### Changes Made

#### `src/App.css`
Changes the color property from blue to black for the MENS title in the 5th large directory menu item

---

### ⚠️ Important

This PR was generated by AI based on a comment/task. Please:

1. **Review all changes carefully** before merging
2. **Test the changes** to ensure they work as expected
3. **Check for any unintended side effects**

---

**Source Comment:** ae068103-53f2-4bc7-b54b-c3d018de0319

*Generated by Halo Frame AI*